### PR TITLE
fix: remove trailing comma in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
 
     "content_scripts": [
         {
-      "matches": ["https://*.openfoodfacts.net/*","https://*.openfoodfacts.org/*","https://*.openpetfoodfacts.org/*","https://*.openproductsfacts.org/*","https://*.openbeautyfacts.org/*",],
+      "matches": ["https://*.openfoodfacts.net/*","https://*.openfoodfacts.org/*","https://*.openpetfoodfacts.org/*","https://*.openproductsfacts.org/*","https://*.openbeautyfacts.org/*"],
 			"css": ["/css/myStyle.css","/css/external/jquery.tagsinput.css"],
 			"run_at": "document_end",
             "js": [


### PR DESCRIPTION
there was a trailing comma in the JSON that prevented installing the extension.

![image](https://user-images.githubusercontent.com/8158668/171872339-f2505b9d-f579-42c8-88fe-0f7a8d03b051.png)
