### PR TITLE
Fix: trailing comma in json not tolerated by Chrome anymore

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
 
     "content_scripts": [
         {
-      "matches": ["https://*.openfoodfacts.net/*","https://*.openfoodfacts.org/*","https://*.openpetfoodfacts.org/*","https://*.openproductsfacts.org/*","https://*.openbeautyfacts.org/*",],
+      "matches": ["https://*.openfoodfacts.net/*","https://*.openfoodfacts.org/*","https://*.openpetfoodfacts.org/*","https://*.openproductsfacts.org/*","https://*.openbeautyfacts.org/*"],
 			"css": ["/css/myStyle.css","/css/external/jquery.tagsinput.css"],
 			"run_at": "document_end",
             "js": [


### PR DESCRIPTION
As per the official JSON spec (https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf) there should be no trailing commas in objects or arrays.

Chrome used to be lenient about it. It seems it is not the case anymore, and trying to install  the extension on Google Chrome v. `119.0.6045.159 (Official Build) (64-bit)` ends in an error about the manifest.json not being valid JSON because of a trailing comma.